### PR TITLE
rewrote the wasm benchmark. updated readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all:
 	cd js && npm install
 	cd neon/native && npm install
-	cd wasm/sha1 && cargo build --release --target=wasm32-unknown-unknown
+	cd wasm && wasm-pack build --release --target nodejs
 	npm install
 	node test.js
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Benchmark to compare sha1 implementation in javascript, web assembly and neon.
 
-Results on my laptop
+Results: (Updated 10-12-2020)
 
 ```
-wasm#short x 30,503 ops/sec ±4.48% (68 runs sampled)
-wasm#long x 17,856 ops/sec ±2.82% (78 runs sampled)
-js#short x 123,116 ops/sec ±1.96% (87 runs sampled)
-js#long x 10,177 ops/sec ±2.75% (81 runs sampled)
-neon#short x 214,933 ops/sec ±1.65% (84 runs sampled)
-neon#long x 68,124 ops/sec ±1.64% (85 runs sampled)
+wasm#short x 229,630 ops/sec ±0.47% (85 runs sampled)
+wasm#long x 114,446 ops/sec ±0.49% (89 runs sampled)
+js#short x 275,967 ops/sec ±0.70% (90 runs sampled)
+js#long x 20,944 ops/sec ±0.63% (89 runs sampled)
+neon#short x 691,628 ops/sec ±0.35% (94 runs sampled)
+neon#long x 188,252 ops/sec ±0.39% (91 runs sampled)
 ```
 
 ## Prerequisites

--- a/neon/native/Cargo.toml
+++ b/neon/native/Cargo.toml
@@ -15,4 +15,4 @@ neon-build = "0.3"
 
 [dependencies]
 neon = "0.3"
-sha1 = "0.2.0"
+sha1 = "0.6.0"

--- a/test.js
+++ b/test.js
@@ -1,25 +1,25 @@
-const wasm = require('./wasm')
+const wasm = require('./wasm/pkg').digest
 const js = require('./js')
 const neon = require('./neon')
 const Benchmark = require('benchmark');
 
 var suite = new Benchmark.Suite;
 
-wasm.ready.then(() => {
-  const libs = ['wasm', 'js', 'neon']
-  libs.forEach(name => {
-    suite.add(name + '#short', () => {
-      const lib = require('./' + name)
-      lib('Hello world')
-    })
-    suite.add(name + '#long', () => {
-      const lib = require('./' + name)
-      lib('Hello world'.repeat(123))
-    })
+
+const libs = ['wasm', 'js', 'neon']
+libs.forEach(name => {
+  suite.add(name + '#short', () => {
+    const lib = require('./' + name)
+    lib('Hello world')
   })
-  suite
-    .on('cycle', function(event) {
-      console.log(String(event.target));
-    })
-    .run({ 'async': true });
+  suite.add(name + '#long', () => {
+    const lib = require('./' + name)
+    lib('Hello world'.repeat(123))
+  })
 })
+suite
+  .on('cycle', function (event) {
+    console.log(String(event.target));
+  })
+  .run({ 'async': true });
+

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sha1-digest"
+version = "0.1.0"
+authors = ["Jan-Erik Rediger <janerik@fnordig.de>"]
+edition = "2018"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+sha1 = "0.6.0"
+wasm-bindgen="0.2.0"
+js-sys="0.3.0"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+#[profile.release]
+#opt-level = "s"

--- a/wasm/index.js
+++ b/wasm/index.js
@@ -1,20 +1,2 @@
-const bundle = require('./bundle')
-const path = require('path')
-
-const Module = {}
-module.exports = function(str) {
-  let buf = bundle.newString(Module, str);
-  let outptr = Module.digest(buf);
-  let result = bundle.copyCStr(Module, outptr);
-  Module.dealloc_str(buf);
-  return result;
-}
-
-module.exports.ready = bundle.fetchAndInstantiate(path.dirname(__filename) + "/sha1/target/wasm32-unknown-unknown/release/sha1_digest.wasm", {})
-.then(mod => {
-  Module.alloc   = mod.exports.alloc;
-  Module.dealloc = mod.exports.dealloc;
-  Module.digest  = mod.exports.digest;
-  Module.memory  = mod.exports.memory;
-  Module.dealloc_str  = mod.exports.dealloc_str;
-});
+import("./pkg")
+module.exports = require("./pkg").digest;

--- a/wasm/sha1/src/lib.rs
+++ b/wasm/sha1/src/lib.rs
@@ -1,42 +1,11 @@
-extern crate sha1;
-
-use std::mem;
-use std::ffi::{CString, CStr};
-use std::os::raw::{c_char, c_void};
-
 use sha1::Sha1;
+use wasm_bindgen::prelude::*;
 
-#[no_mangle]
-pub extern "C" fn alloc(size: usize) -> *mut c_void {
-    let mut buf = Vec::with_capacity(size);
-    let ptr = buf.as_mut_ptr();
-    mem::forget(buf);
-    return ptr as *mut c_void;
-}
+#[wasm_bindgen]
+pub fn digest(string: &str) -> Option<String> {
+    let mut m = Sha1::new();
+    m.update(string.as_bytes());
+    let dgst = m.digest().to_string();
 
-#[no_mangle]
-pub extern "C" fn dealloc(ptr: *mut c_void, cap: usize) {
-    unsafe  {
-        let _buf = Vec::from_raw_parts(ptr, 0, cap);
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn dealloc_str(ptr: *mut c_char) {
-    unsafe {
-        let _ = CString::from_raw(ptr);
-    }
-}
-
-#[no_mangle]
-pub extern "C" fn digest(data: *mut c_char) -> *mut c_char {
-    unsafe {
-        let data = CStr::from_ptr(data);
-
-        let mut m = Sha1::new();
-        m.update(data.to_bytes());
-        let dgst = m.digest().to_string();
-        let s = CString::new(dgst).unwrap();
-        s.into_raw()
-    }
+    Some(dgst)
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,64 @@
+use wasm_bindgen::prelude::*;
+use sha1::Sha1;
+// /use js_sys::Promise;
+
+/*#[wasm_bindgen]
+extern "C" {
+
+}*/
+
+#[wasm_bindgen]
+pub fn digest(string: &str) -> Option<String> {
+
+    //let string = cx.argument::<JsString>(0)?.value();
+
+    let mut m = Sha1::new();
+    m.update(string.as_bytes());
+    let dgst= m.digest().to_string();
+    
+    Some(dgst)
+
+    
+}
+/*
+register_module!(mut m, {
+    m.export_function("digest", digest)?;
+    Ok(())
+});
+*/
+/*
+#[no_mangle]
+pub extern "C" fn alloc(size: usize) -> *mut c_void {
+    let mut buf = Vec::with_capacity(size);
+    let ptr = buf.as_mut_ptr();
+    mem::forget(buf);
+    return ptr as *mut c_void;
+}
+
+#[no_mangle]
+pub extern "C" fn dealloc(ptr: *mut c_void, cap: usize) {
+    unsafe  {
+        let _buf = Vec::from_raw_parts(ptr, 0, cap);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn dealloc_str(ptr: *mut c_char) {
+    unsafe {
+        let _ = CString::from_raw(ptr);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn digest(data: *mut c_char) -> *mut c_char {
+    unsafe {
+        let data = CStr::from_ptr(data);
+
+        let mut m = Sha1::new();
+        m.update(data.to_bytes());
+        let dgst = m.digest().to_string();
+        let s = CString::new(dgst).unwrap();
+        s.into_raw()
+    }
+}
+*/


### PR DESCRIPTION
NOTE: I'm fairly new to rust and extremely new to javascript, if I need to change anything, I can. definitely open to further improvements to the benchmarks.

I rewrote the wasm implementation to make it closer in code complexity to the neon implementation (actually started by copying the equivalent neon function), and this led to a major performance improvement. the original local benchmarks were:
```
wasm#short x 77,917 ops/sec ±0.57% (82 runs sampled)
wasm#long x 34,726 ops/sec ±1.20% (82 runs sampled)
js#short x 275,189 ops/sec ±0.69% (92 runs sampled)
js#long x 21,498 ops/sec ±0.75% (89 runs sampled)
neon#short x 644,123 ops/sec ±0.34% (92 runs sampled)
neon#long x 182,730 ops/sec ±0.32% (91 runs sampled)
```
after the modifications to the wasm portion:
```
wasm#short x 229,630 ops/sec ±0.47% (85 runs sampled)
wasm#long x 114,446 ops/sec ±0.49% (89 runs sampled)
js#short x 275,967 ops/sec ±0.70% (90 runs sampled)
js#long x 20,944 ops/sec ±0.63% (89 runs sampled)
neon#short x 691,628 ops/sec ±0.35% (94 runs sampled)
neon#long x 188,252 ops/sec ±0.39% (91 runs sampled)
```
the majority of the changes were to the wasm portion. I only removed the `ready.then` block from test.js, and changed the build instructions for the wasm portion in the Makefile (switching from `cargo` to `wasm-pack` for compilation). I also updated the readme  with the new benchmarks.